### PR TITLE
Add print button and retrieve passages live on startup

### DIFF
--- a/app.html
+++ b/app.html
@@ -42,7 +42,7 @@
 <script type="text/javascript" src="javascripts/functions.js"></script>
 </head>
 
-<body onload="javascript: loadText();">
+<body onload="javascript: parse();">
 <div id="instructions" class="noprint">
 <p>
 <b>Instructions</b><br />Type in the passage(s) that you would like to translate in the input form below. Then press "Retrieve passages" and wait as the translations are retrieved. Depending on how many passages you are searching for, this can take anywhere from 5 seconds to almost a minute. The results will be displayed below. You can copy and paste the results in the ECM template document.</p>
@@ -50,7 +50,7 @@
 <b>Instructions for Printing Bulletin Inserts</b><br />Paste the text onto two pages, then print with two-sided layout, flipping on the short edge. After the sheet has been printed, cutting it half will produce two identical inserts.
 </p>
 Type passage reference(s) here (i.e. John 3:16; Ps. 46:10; 1 John 1:9-10) <br />
-<input value="John 3:16; Ps. 46:10; 1 John 1:9-10" type="text" size="100" id="input" onkeydown="javascript: if (window.event.keyCode == 13) { parse(); };" autofocus /><br /><a href="#" id="submit" class="button white" onclick="javascript: parse();">Retrieve passages</a>
+<input value="John 3:16; Ps. 46:10; 1 John 1:9-10" type="text" size="100" id="input" onkeydown="javascript: if (window.event.keyCode == 13) { parse(); };" autofocus /><br /><a href="#" id="submit" class="button white" onclick="javascript: parse();">Retrieve passages</a> <a href="#" id="print" class="button white" onclick="javascript: window.print(); return false;">Print passages</a>
 
 <span id="progress" style="padding-left: 10px; display: none;"><img src="assets/ajax-loader.gif" /></span>
 

--- a/javascripts/functions.js
+++ b/javascripts/functions.js
@@ -167,14 +167,3 @@ function toggleVerses(translation) {
         verseNum.style.display = (verseNum.style.display == '' ? 'none' : '');
       });
 }
-
-function loadText() {
-  var xmlHttp = new XMLHttpRequest();
-  xmlHttp.open("GET", "../assets/init.html");
-  xmlHttp.send(null);
-
-  xmlHttp.onreadystatechange = function() {
-    // document.getElementById("output").innerHTML = '';
-    document.getElementById("output").innerHTML = xmlHttp.responseText;
-  }
-}


### PR DESCRIPTION
Resolves two of the open issues.

## Changes

### Resolves #5 — Print verses directly from the app
Adds a **"Print passages"** button next to "Retrieve passages" in `app.html`. It calls `window.print()` and relies on the existing `stylesheets/print.css` media query (two-column landscape layout, UI chrome hidden). The button lives inside the `#instructions` `noprint` block, so it doesn't appear on the printed page.

### Resolves #4 — Retrieve passages on startup instead of hard-coding init.html
On page load the app now runs the actual retrieve code (`parse()`) against the default input, instead of injecting the stale, hard-coded `assets/init.html` snapshot via `loadText()`. Removed the now-unused `loadText()` from `javascripts/functions.js`.

## Files touched
- `app.html` — `onload` now calls `parse()`; added the Print button
- `javascripts/functions.js` — removed dead `loadText()`

## Not addressed here
- **#3** (repeated bible.com passages) lives in the disabled `assets/application2.php` scraper and depends on bible.com's 2017-era markup; needs the integration revived/rewritten first.
- **#6** (offline Bible) is a larger feature — bundling full translation datasets and a local lookup layer — better scoped separately.

## Testing notes
The frontend changes are wired to the existing print CSS and retrieval path. End-to-end retrieval could not be exercised here since it depends on the PHP backend (`application.php`) live-scraping biblegateway.com, which requires a PHP runtime and network access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RwBVV4mnX4QyCFybYgfjmg

---
_Generated by [Claude Code](https://claude.ai/code/session_01RwBVV4mnX4QyCFybYgfjmg)_