### PR TITLE
Fix XPath injection in Bible.com chapter lookup; bump symfony/routing

### DIFF
--- a/assets/application.php
+++ b/assets/application.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/fetcher.php';
 
-$passages = explode(",", $_GET['passages']);
+$passages = explode(",", $_GET['passages'] ?? '');
 $translations = ["ESV", "CNVT", "NVI", "RUSV", "BPT", "FSV", "NVI-PT"];
 $languages = ["English", "Chinese (Traditional)", "Spanish", "Russian", "Vietnamese", "Tagalog", "Portuguese"];
 
@@ -48,7 +48,10 @@ foreach ($translations as $translation) {
 		if ($title === null) {
 			$body .= "<div>Sorry, $passage could not be found for this translation.</div>";
 		} else {
-			$body .= "<div style='text-align: center'><span class='fleuron'>d</span>  $title  <span class='fleuron'>c</span></div>";
+			// The heading is scraped out of BibleGateway's markup, which echoes
+			// back part of the search string, so it is escaped before printing.
+			$safe_title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+			$body .= "<div style='text-align: center'><span class='fleuron'>d</span>  $safe_title  <span class='fleuron'>c</span></div>";
 		}
 
 		$text = "";

--- a/assets/application2.php
+++ b/assets/application2.php
@@ -13,8 +13,8 @@ $languages    = ["KRV" => "Korean", "JLB" => "Japanese", "FCB" => "Farsi"];
 $biblegateway_url = "https://www.biblegateway.com/passage/";
 $bible_com_url    = "https://www.bible.com/bible";
 
-$passages = json_decode($_GET['passages'], true);
-$verses   = json_decode($_GET['verses'], true);
+$passages = json_decode($_GET['passages'] ?? '', true);
+$verses   = json_decode($_GET['verses'] ?? '', true);
 if (!is_array($passages)) { $passages = []; }
 if (!is_array($verses))   { $verses = []; }
 
@@ -82,6 +82,8 @@ function query_all($finder, $expr, $context) {
 
 // Turns one fetched Bible.com chapter into printable HTML containing only the
 // requested verses. Returns null if the chapter could not be parsed.
+// $chapter_usfm is interpolated into the XPath below, so callers must pass a
+// value they have validated (BOOK.chapter, letters and digits only).
 function render_chapter($html, $chapter_usfm, $wanted_verses) {
 	list($dom, $finder) = xpath_for($html);
 
@@ -150,19 +152,26 @@ foreach ($translations as $translation => $bibleID) {
 	$body .= "<div id='$translation' class='translation'>";
 
 	foreach ($chapter_refs as $chapter => $refs) {
-		// "Mark 1" -> "MRK.1"
-		$parts = explode(" ", $chapter);
-		$book_index = array_search($parts[0], $bcv_books);
+		// "Mark 1" -> "MRK.1". The chapter reference arrives from the query
+		// string and ends up inside an XPath predicate in render_chapter(), so
+		// only a known book name followed by a plain chapter number is accepted;
+		// anything else is dropped rather than escaped.
+		if (!preg_match('/^(\\S+) (\\d+)$/', $chapter, $m)) {
+			continue;
+		}
+		$book_index = array_search($m[1], $bcv_books);
 		if ($book_index === false) {
 			continue;
 		}
-		$parts[0] = $bible_com_books[$book_index];
-		$chapter_usfm = implode(".", $parts);
+		$chapter_usfm = $bible_com_books[$book_index] . "." . $m[2];
 
 		$body .= "<div class='passages'>";
 		$title = heading_for($refs);
 		if ($title !== null) {
-			$body .= "<div style='text-align: center'><span class='fleuron'>d</span>  $title  <span class='fleuron'>c</span></div>";
+			// The heading is scraped out of BibleGateway's markup, which echoes
+			// back part of the search string, so it is escaped before printing.
+			$safe_title = htmlspecialchars($title, ENT_QUOTES, 'UTF-8');
+			$body .= "<div style='text-align: center'><span class='fleuron'>d</span>  $safe_title  <span class='fleuron'>c</span></div>";
 		}
 
 		$html = fetch_url("$bible_com_url/$bibleID/" . rawurlencode($chapter_usfm));

--- a/composer.lock
+++ b/composer.lock
@@ -945,16 +945,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -1005,7 +1005,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -1025,20 +1025,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v5.4.48",
+            "version": "v5.4.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "dd08c19879a9b37ff14fd30dcbdf99a4cf045db1"
+                "reference": "f4ca0c533854c26e3b27e981da760807f89e1a42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/dd08c19879a9b37ff14fd30dcbdf99a4cf045db1",
-                "reference": "dd08c19879a9b37ff14fd30dcbdf99a4cf045db1",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/f4ca0c533854c26e3b27e981da760807f89e1a42",
+                "reference": "f4ca0c533854c26e3b27e981da760807f89e1a42",
                 "shasum": ""
             },
             "require": {
@@ -1099,7 +1099,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.4.48"
+                "source": "https://github.com/symfony/routing/tree/v5.4.53"
             },
             "funding": [
                 {
@@ -1111,11 +1111,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T18:20:21+00:00"
+            "time": "2026-05-22T19:02:28+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -1543,5 +1547,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Summary

Two security fixes.

**XPath injection (`assets/application2.php`)** — the chapter reference from the `passages` query parameter was interpolated directly into an XPath predicate in `render_chapter()`. Only the first token was validated against the book list, so anything after the first space could break out of the string literal:

```
?passages={"x":["Mark 1'] | //*[@a='"]}
```

That runs arbitrary XPath against the fetched document, or produces a malformed expression that makes `DOMXPath::query()` return `false` and blow up `query_all()`. The whole chapter string is now validated as `<book> <number>` and the USFM identifier rebuilt from the matched parts; anything that does not fit is dropped rather than escaped.

**symfony/routing** — bumped v5.4.48 → v5.4.53, closing `GHSA-72xp-p242-47p9` and `GHSA-h5x3-xfc9-m39h`. `composer.json`'s `^5.4` constraint already allowed it, so only the lock file changes (plus polyfill-php80 v1.33.0 → v1.37.0 transitively).

## Also hardened

- The heading scraped out of BibleGateway's markup is escaped before printing, in both `application.php` and `application2.php` — that markup reflects part of the search string.
- `$_GET['passages']` / `$_GET['verses']` default to `''`, so a request without them does not emit warnings or hit `json_decode(null)`.

## Testing

- `php -l` clean on both changed files.
- End-to-end run with the payload above: the injected entry is dropped, one `Mark 1` block renders, no XPath error. (Bible.com itself returned nothing on that run — bot challenge with no cache present, pre-existing and unrelated.)
- `composer audit` reports no advisories.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YLeD3HwdCzCEpJQ47Pb9xs